### PR TITLE
User feedback round: portfolio fixes, new features, and live-site bug corrections

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, useLocation } from 'react-router-dom';
 import { AnimatePresence } from 'framer-motion';
+import { useEffect } from 'react';
 
 import Nav from './components/layout/Nav';
 import Footer from './components/layout/Footer';
@@ -28,6 +29,11 @@ import AdminSettings from './pages/admin/AdminSettings';
 function AnimatedRoutes() {
   const location = useLocation();
   const isAdmin = location.pathname.startsWith('/admin');
+
+  // Scroll to top on every route change so mobile nav links land at the page top
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [location.pathname]);
 
   return (
     <>

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -72,7 +72,7 @@ export default function Contact() {
       </section>
 
       {/* ── Form ────────────────────────────────────────────────────────────── */}
-      <section className="section px-6" style={{ background: 'var(--color-bg-cream)' }}>
+      <section className="px-6 pt-16 pb-20" style={{ background: 'var(--color-bg-cream)' }}>
         <div className="container mx-auto max-w-2xl">
           <AnimatePresence mode="wait">
             {status === 'success' ? (

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -46,7 +46,7 @@ const quickLinks = [
 function ShowcaseCard({ item }: { item: ShowcaseItem }) {
   const inner = (
     <motion.div
-      className="cursor-pointer"
+      className="cursor-pointer group"
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
@@ -56,15 +56,17 @@ function ShowcaseCard({ item }: { item: ShowcaseItem }) {
         <div className="aspect-[2/3] relative overflow-hidden">
           {item.posterUrl ? (
             <img src={item.posterUrl} alt={item.title} loading="lazy"
-              className="portfolio w-full h-full object-cover" />
+              className="portfolio w-full h-full object-cover transition-transform duration-500 group-hover:scale-[1.03]" />
           ) : (
             <div className="w-full h-full flex items-center justify-center font-display italic text-6xl"
               style={{ background: 'linear-gradient(160deg, #004040, #008080 60%, #C9A9A6)', color: 'rgba(255,255,255,0.15)' }}>
               {item.title.charAt(0)}
             </div>
           )}
-          <div className="absolute inset-0 flex flex-col justify-end p-5 home-poster-overlay"
-            style={{ background: 'linear-gradient(to top, rgba(0,40,40,0.95) 0%, rgba(0,40,40,0) 60%)' }}>
+          <div
+            className="absolute inset-0 flex flex-col justify-end p-5 translate-y-[60%] group-hover:translate-y-0 transition-transform duration-300 ease-out"
+            style={{ background: 'linear-gradient(to top, rgba(0,40,40,0.95) 0%, rgba(0,40,40,0) 60%)' }}
+          >
             <div className="font-display text-xl font-semibold" style={{ color: 'var(--color-text-inverse)' }}>
               {item.title}
             </div>
@@ -285,12 +287,6 @@ export default function Home() {
       {/* ── Featured work showcase ──────────────────────────────────────────── */}
       {showcase.length > 0 && (
         <section className="px-6 py-20" style={{ background: 'var(--color-bg-cream)' }}>
-          <style>{`
-            .home-poster-overlay { transform: translateY(60%); transition: transform 300ms ease-out; }
-            .cursor-pointer:hover .home-poster-overlay { transform: translateY(0); }
-            .cursor-pointer:hover img.portfolio { filter: none; transform: scale(1.03); }
-            img.portfolio { transition: filter 400ms ease, transform 500ms ease; }
-          `}</style>
           <div className="container mx-auto" style={{ maxWidth: '72rem' }}>
             <motion.div
               initial={{ opacity: 0, y: 16 }}

--- a/frontend/src/pages/portfolio/Writing.tsx
+++ b/frontend/src/pages/portfolio/Writing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { motion, AnimatePresence } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { getWritingProjects } from '../../api/writing';
 import type { WritingProject } from '../../api/types';
 
@@ -276,17 +276,9 @@ export default function Writing() {
             </p>
           )}
 
-          <AnimatePresence mode="wait">
-            <motion.div
-              key={filter}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              exit={{ opacity: 0 }}
-              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8"
-            >
-              {visible.map(p => <PosterCard key={p.id} project={p} />)}
-            </motion.div>
-          </AnimatePresence>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
+            {visible.map(p => <PosterCard key={p.id} project={p} />)}
+          </div>
         </div>
       </section>
     </motion.main>

--- a/supabase/functions/contact-notify/index.ts
+++ b/supabase/functions/contact-notify/index.ts
@@ -2,10 +2,10 @@
 // submits the contact form. Invoked from the frontend after the row is saved.
 //
 // Env vars (set in Supabase dashboard → Edge Functions → contact-notify):
-//   SMTP_HOST       e.g. smtp.zoho.eu  or  smtp.zoho.com
-//   SMTP_PORT       e.g. 587
+//   SMTP_HOST       smtp.zoho.eu  (EU accounts) or smtp.zoho.com
+//   SMTP_PORT       465  ← recommended (implicit TLS); 587 = STARTTLS also works
 //   SMTP_USERNAME   e.g. kat_writes@whataline.com
-//   SMTP_PASSWORD   Zoho app-specific password
+//   SMTP_PASSWORD   Zoho app-specific password (Settings → Security → App Passwords)
 //   EMAIL_FROM      e.g. kat_writes@whataline.com
 //   EMAIL_TO        e.g. kat_writes@whataline.com (where notifications land)
 
@@ -34,11 +34,13 @@ Deno.serve(async (req) => {
       ? `New message from ${payload.name}: ${payload.subject}`
       : `New message from ${payload.name}`;
 
+    const port = Number(Deno.env.get('SMTP_PORT') ?? 465);
     const client = new SMTPClient({
       connection: {
         hostname: Deno.env.get('SMTP_HOST')!,
-        port:     Number(Deno.env.get('SMTP_PORT') ?? 587),
-        tls:      true,
+        port,
+        // port 465 = implicit TLS (SSL); port 587 = STARTTLS (no immediate TLS)
+        tls: port !== 587,
         auth: {
           username: Deno.env.get('SMTP_USERNAME')!,
           password: Deno.env.get('SMTP_PASSWORD')!,


### PR DESCRIPTION
## Summary

This branch collects two rounds of user feedback fixes plus a suite of live-site bug corrections.

---

### Round 1 — Portfolio & content fixes

**Services — work sample not displaying**
Added an explicit FK hint (`service_samples!service_id(...)`) to the Supabase nested select so PostgREST reliably joins samples for anonymous (public) queries.

**Awards — festival name missing**
Films and Writing pages were rendering laurel awards as images with the festival name only in the `alt` attribute (tooltip-only). Both pages now render the festival name and year as visible text below the laurel image.

**Writing page — poster fallback**
Added an `onError` state handler to `PosterCard` so broken poster URLs fall back gracefully to the gradient-initial-letter placeholder.

**About page — layout overhaul**
- Profile photo and heading/bio moved into a two-column grid (photo left, text right)
- Gallery photo array updated with the 7 real photos added to `public/photos/`
- Gallery background changed to dark teal for contrast
- Awards & Laurels section eyebrow adapts based on whether laurel data exists

**Testimonials — multi-paragraph support**
Long quotes stored with newline separators now split into proper `<p>` tags instead of collapsing into a single block.

**Photos uploaded**
7 real photos added to `frontend/public/photos/`: `profile.jpg`, `bts-on-set.jpg`, `bts-on-set-2.jpg`, `bts-on-set-3.jpg`, `bts-on-set-4.jpg`, `bts-screening.jpg`, `southend-festival.jpg`.

---

### Round 1 — New features (already coded, needed DB migration)

The laurels system (laurel image upload + featured toggle on awards), social links footer, and home page featured poster grid were already fully implemented in code. Only the DB migration was missing.

**Migration: `supabase/migrations/add_laurels_and_socials.sql`**
- Adds `laurel_url` and `featured` columns to the `awards` table
- Creates the `social_links` table with RLS policies
- Seeds LinkedIn, IMDB, Instagram, and YouTube links for Kat
- Made fully idempotent (`DROP POLICY IF EXISTS`, `CREATE TABLE IF NOT EXISTS`, conflict-safe seed)

> **To apply:** run this SQL in the Supabase SQL Editor.

---

### Round 2 — Live-site bug fixes

**Contact page — top spacing**
Form section was flush against the hero. Added `pt-16 pb-20` padding.

**Home page featured posters — overlay always visible**
The hover overlay on showcase cards was controlled by a `<style>` tag inside a `showcase.length > 0` conditional. The CSS was absent during first render, leaving the overlay in its default (visible) position. Replaced with Tailwind `group` / `group-hover:translate-y-0` / `translate-y-[60%]` — no DOM-timing dependency.

**Nav links — scroll position on navigation**
Tapping a mobile nav link navigated correctly but left the page at the previous scroll position. Added `window.scrollTo(0, 0)` to a `useEffect` watching `location.pathname` in `AnimatedRoutes` so every route change starts at the top.

**Writing page filter buttons — scroll jump**
Clicking ALL / FEATURE / SERIES caused the page to jump because `AnimatePresence mode=wait` with `key={filter}` unmounted the entire grid during the filter transition, collapsing the page height. Removed the `AnimatePresence` wrapper; individual `PosterCard` entries still animate in via their own `whileInView`.

**Contact form emails — SMTP TLS mismatch**
The Edge Function hardcoded `tls: true`, which is correct for port 465 (implicit TLS/SSL) but breaks port 587 (STARTTLS). Fixed to derive the flag from the configured port (`tls: port !== 587`). Default port changed from 587 to 465. Env var comment updated to reference Zoho app-specific passwords.

> **Action required:** confirm the five Supabase Edge Function secrets are set under Dashboard → Edge Functions → `contact-notify` → Secrets: `SMTP_HOST`, `SMTP_PORT` (465), `SMTP_USERNAME`, `SMTP_PASSWORD`, `EMAIL_FROM`, `EMAIL_TO`.

---

## Test plan

- [ ] Services page: expand a service and confirm work samples appear (public, not logged in)
- [ ] Films page: awards with a laurel image show festival name/year below the laurel
- [ ] Writing page: same award rendering; filter pills (ALL / FEATURE / SERIES) switch without page scroll jump
- [ ] Writing page: poster with a broken URL falls back to the letter placeholder
- [ ] About page: photo + bio appear side-by-side; gallery shows 6 real BTS/festival photos
- [ ] Testimonials: multi-paragraph quotes render as separate `<p>` elements
- [ ] Home page: featured posters grid appears; logline overlay is hidden until hover
- [ ] Footer: social link icons (LinkedIn, IMDB, Instagram, YouTube) appear (requires migration + seed)
- [ ] Nav: tap a link from the mobile hamburger — new page loads at the very top
- [ ] Contact page: form has adequate space below the hero
- [ ] Contact form: submit a test message and confirm the notification email arrives at `EMAIL_TO`
- [ ] Run the `add_laurels_and_socials.sql` migration on the live DB (idempotent — safe to run again)

🤖 Generated with [Claude Code](https://claude.com/claude-code)