### PR TITLE
fix: device compat for Z Flip cover screen and Samsung Internet

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -40,7 +40,7 @@ export default function Footer() {
           </div>
 
           {/* Nav columns */}
-          <nav className="grid grid-cols-2 gap-x-12 gap-y-3" aria-label="Footer navigation">
+          <nav className="grid grid-cols-2 gap-x-6 gap-y-3 sm:gap-x-12" aria-label="Footer navigation">
             {footerLinks.map(({ to, label }) => (
               <Link
                 key={to}

--- a/frontend/src/components/layout/Nav.tsx
+++ b/frontend/src/components/layout/Nav.tsx
@@ -51,7 +51,7 @@ export default function Nav() {
         className="fixed top-0 left-0 right-0 z-50 transition-all duration-300"
         style={
           scrolled || !hasDarkHero
-            ? { background: 'rgba(244,238,239,0.95)', backdropFilter: 'blur(8px)', borderBottom: '1px solid rgba(0,64,64,0.08)' }
+            ? { background: 'rgba(244,238,239,0.95)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', borderBottom: '1px solid rgba(0,64,64,0.08)' }
             : { background: 'transparent' }
         }
       >

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -104,6 +104,17 @@ img.portfolio:hover {
   flex-shrink: 0;
 }
 
+/* ── Narrow-screen padding relief (Z Flip cover screen ≤ 320 px) ───────────── */
+/* Sections nest a px-6 section + a .container, each carrying 1.5rem padding.  */
+/* At 260 px that stacks to 48 px/side → 164 px content. Halving the container  */
+/* padding below 320 px gives back ~20 px without changing any other breakpoint. */
+@media (max-width: 320px) {
+  .container {
+    padding-left: 0.5rem;
+    padding-right: 0.5rem;
+  }
+}
+
 /* ── Prefers reduced motion ─────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -113,7 +113,7 @@ export default function About() {
             {/* Profile photo — left column */}
             <motion.div
               {...fadeUp(0.1)}
-              className="w-44 sm:w-52 md:w-60 flex-shrink-0 mx-auto md:mx-0"
+              className="w-44 sm:w-52 md:w-60 max-w-full flex-shrink-0 mx-auto md:mx-0"
             >
               <img
                 src="/photos/profile.jpg"
@@ -321,7 +321,7 @@ export default function About() {
       <section className="section px-6" style={{ background: 'var(--color-bg-dark)' }}>
         <div className="container mx-auto max-w-4xl">
           <motion.div {...fadeUp(0)} className="eyebrow" style={{ color: 'rgba(250,247,248,0.55)' }}>Behind the Scenes</motion.div>
-          <div className="mt-10 grid grid-cols-2 md:grid-cols-3 gap-4">
+          <div className="mt-10 grid grid-cols-1 min-[360px]:grid-cols-2 md:grid-cols-3 gap-4">
             {galleryPhotos.map((photo, i) => (
               <motion.figure
                 key={photo.src}

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -307,7 +307,7 @@ export default function Home() {
             >
               Selected films &amp; scripts
             </motion.h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 min-[360px]:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
               {showcase.map((item) => (
                 <ShowcaseCard key={`${item.kind}-${item.id}`} item={item} />
               ))}

--- a/frontend/src/pages/portfolio/Writing.tsx
+++ b/frontend/src/pages/portfolio/Writing.tsx
@@ -235,7 +235,7 @@ export default function Writing() {
       {!loading && formats.length > 2 && (
         <section
           className="py-6 px-6 sticky top-[64px] z-30"
-          style={{ background: 'rgba(250,247,242,0.95)', backdropFilter: 'blur(8px)', borderBottom: '1px solid rgba(0,64,64,0.08)' }}
+          style={{ background: 'rgba(250,247,242,0.95)', backdropFilter: 'blur(8px)', WebkitBackdropFilter: 'blur(8px)', borderBottom: '1px solid rgba(0,64,64,0.08)' }}
         >
           <div className="container mx-auto flex flex-wrap gap-2">
             {formats.map(f => (


### PR DESCRIPTION
## Summary

Targeted device-compatibility fixes for two specific devices: the Samsung Galaxy Z Flip 4 (cover and inner screen) and Firefox on Android. No functional behaviour changes — purely layout and rendering fixes.

---

## Samsung Galaxy Z Flip 4 — Cover screen (~260 CSS px wide)

The cover screen is about 260 px wide in CSS pixels. Several layouts that look fine on a standard 375 px phone break at this width.

**Root cause: double-padding stack**
Most page sections nest content as `<section className="px-6">` wrapping `<div className="container mx-auto">`. The section adds 24 px padding on each side; the Tailwind container config also carries a default 24 px padding — stacking to 48 px/side, leaving only 164 px of content width at 260 px viewport.

### Fixes applied

| File | Problem | Fix |
|---|---|---|
| `index.css` | Container + section padding double-stacks at narrow widths | Added `@media (max-width: 320px)` rule halving `.container` padding to `0.5rem`, recovering ~20 px of content width |
| `About.tsx` | Profile photo `w-44` (176 px) overflows its 164 px container | Added `max-w-full` — photo scales down rather than spilling outside its bounds |
| `About.tsx` | Gallery `grid-cols-2` gives ~70 px cells at cover-screen width | Changed to `grid-cols-1 min-[360px]:grid-cols-2` — single column on cover screen, 2 cols on inner screen and normal phones |
| `Home.tsx` | Showcase `grid-cols-2` gives ~70 px poster cards — unusably tiny | Same fix: `grid-cols-1 min-[360px]:grid-cols-2` |
| `Footer.tsx` | Nav link columns use `gap-x-12` (48 px) — "Testimonials" overflows its column | Reduced to `gap-x-6` on mobile, `sm:gap-x-12` restores original spacing at 640 px+ |

**Inner screen (~360 CSS px in portrait, ~880 px in landscape)**
At 360 px portrait the `min-[360px]:` threshold kicks in, giving the same 2-column layouts as a normal phone. Landscape maps to a desktop breakpoint and uses the existing 3/4-column grids.

---

## Samsung Internet (Z Flip default browser — WebKit/Blink engine)

Samsung Internet uses a Chromium/WebKit engine. `backdrop-filter` requires the `-webkit-backdrop-filter` vendor prefix for older Samsung Internet versions (pre-2022).

| File | Fix |
|---|---|
| `Nav.tsx` | Added `WebkitBackdropFilter: 'blur(8px)'` alongside `backdropFilter` for the frosted-glass scrolled nav |
| `Writing.tsx` | Same prefix added to the sticky filter bar |

---

## Firefox on Android (Pixel 10 — Gecko engine)

Full audit of the codebase against Firefox/Gecko was performed. **No code-level breakages found.** Specifically:

- `backdrop-filter` — supported natively in Firefox 103+ (no `-webkit-` prefix needed; current Android Firefox is 130+)
- Flexbox/Grid `gap` — supported since Firefox 63
- `aspect-ratio` — supported since Firefox 89
- `position: sticky` — supported since Firefox 59
- `clamp()` — supported since Firefox 75
- CSS custom properties — supported since Firefox 31
- `mix-blend-mode` — supported since Firefox 32
- Framer Motion transforms (`translateY`, `scale`, `opacity`) — standard CSS, fully supported
- `window.scrollTo(0, 0)` on nav transitions — fully supported
- YouTube IFrame API muted autoplay — permitted by Firefox

No Firefox-specific code changes were required.

---

## Test plan

### Z Flip cover screen (Chrome DevTools: custom 260x512)
- [ ] Home: featured poster grid shows **1 column** of cards (not 2 tiny ones)
- [ ] About: profile photo fits within the page width (no horizontal scroll)
- [ ] About: gallery shows **1 column** of photos
- [ ] Footer: "Testimonials" link text doesn't overflow its column
- [ ] No horizontal scrollbar on any page

### Z Flip inner screen (Chrome DevTools: custom 360x880 portrait)
- [ ] Home: featured poster grid shows **2 columns**
- [ ] About: gallery shows **2 columns**
- [ ] All other pages use standard single-column mobile styles

### Samsung Internet (test on device or BrowserStack)
- [ ] Scrolled nav has frosted-glass blur effect (was solid on older Samsung Internet)
- [ ] Writing filter bar has blur effect when sticky

### Firefox on Android
- [ ] All pages load and render correctly
- [ ] Nav blur, sticky filter bar, and poster hover overlays all work
- [ ] Scroll-to-top on nav tap works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
