### PR TITLE
fix: invert laurel images on About page dark background

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -237,7 +237,7 @@ export default function About() {
                   return (
                     <motion.div key={l.id} {...fadeUp(i * 0.08)} className="flex flex-col items-center text-center gap-3">
                       {l.laurelUrl ? (
-                        <img src={l.laurelUrl} alt={l.name} className="h-24 w-auto object-contain" />
+                        <img src={l.laurelUrl} alt={l.name} className="h-24 w-auto object-contain invert" />
                       ) : (
                         <div className="flex flex-col gap-1 px-6 py-3"
                           style={{ border: '1px solid rgba(250,247,248,0.25)' }}>


### PR DESCRIPTION
## Summary

Black laurel PNG images are invisible against the teal dark background of the About page's Awards & Laurels section.

## Change

Added Tailwind's invert class to the laurel <img> element in About.tsx (line 240). This inverts black-on-transparent PNGs to white-on-transparent at render time — no duplicate image assets needed.

Films and Writing pages are **not affected**: their laurel images render on light cream backgrounds where the original black assets are correct.

## Before / After

| Page | Background | Laurel colour | Change |
|---|---|---|---|
| Films | Cream (#F4EEEF) | Black | No change |
| Writing | Cream (#F4EEEF) | Black | No change |
| About | Teal dark (#008080) | ~~Black (invisible)~~ → **White** | invert added |

## Test plan

- [ ] Add a featured laurel award to any film or script in the admin panel
- [ ] Visit the About page → Awards & Laurels section: laurel image should appear **white**
- [ ] Visit Films or Writing page: same laurel image should still appear **black** (no change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)