### PR TITLE
fix: home showcase overlay hidden on mobile, subtitle contrast

### DIFF
--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -64,7 +64,7 @@ function ShowcaseCard({ item }: { item: ShowcaseItem }) {
             </div>
           )}
           <div
-            className="absolute inset-0 flex flex-col justify-end p-5 translate-y-[60%] group-hover:translate-y-0 transition-transform duration-300 ease-out"
+            className="absolute inset-0 hidden md:flex flex-col justify-end p-5 md:translate-y-[60%] md:group-hover:translate-y-0 md:transition-transform md:duration-300 md:ease-out"
             style={{ background: 'linear-gradient(to top, rgba(0,40,40,0.95) 0%, rgba(0,40,40,0) 60%)' }}
           >
             <div className="font-display text-xl font-semibold" style={{ color: 'var(--color-text-inverse)' }}>
@@ -88,7 +88,7 @@ function ShowcaseCard({ item }: { item: ShowcaseItem }) {
           {item.title}
         </div>
         {(item.format || item.genre) && (
-          <div className="font-body text-xs mt-0.5" style={{ color: 'var(--color-text-muted)' }}>
+          <div className="font-body text-xs mt-0.5" style={{ color: 'var(--color-text-secondary)' }}>
             {[item.format, item.genre].filter(Boolean).join(' · ')}
           </div>
         )}


### PR DESCRIPTION
## Summary

Two mobile-visible regressions on the home page featured posters grid, both in `ShowcaseCard` inside `Home.tsx`.

---

## Fix 1 — Overlay permanently visible on mobile

### Root cause

The overlay was hidden using `translate-y-[60%]` and revealed on hover with `group-hover:translate-y-0`. This approach depends on `overflow: hidden` on the parent container clipping the translated child. **WebKit/Blink on iOS and Android does not reliably clip `transform`-ed absolutely-positioned children inside `overflow: hidden` containers** — a long-standing browser quirk — so the dark gradient overlay bleeds through on mobile regardless of the translate value.

Additionally, touch devices have no `:hover` state, so the overlay would never animate in intentionally on mobile anyway.

### Fix

Replaced the translate-based hide/show with a simpler `display` approach:

| Breakpoint | Before | After |
|---|---|---|
| Mobile (`< md`, `< 768px`) | `flex` + `translate-y-[60%]` (leaks through) | `hidden` (display: none — completely removed from rendering) |
| Desktop (`md+`, `768px+`) | `flex` + hover translate | `md:flex` + `md:group-hover:translate-y-0` (unchanged behaviour) |

The overlay is now completely absent from the DOM on mobile, keeping poster cards clean. On desktop the hover slide-in effect is preserved exactly as before.

---

## Fix 2 — Category/genre subtitle hard to read

The format + genre line ("Short · Drama") beneath each poster title used `--color-text-muted` (`#A6C6C9`) — a very light turquoise that has insufficient contrast against the cream page background (`#F4EEEF`).

Changed to `--color-text-secondary` (`#008080`, solid teal), which is clearly readable while remaining visually subordinate to the title above it.

---

## Files changed

- `frontend/src/pages/Home.tsx` — `ShowcaseCard` component only; 2 lines changed

## Test plan

- [ ] Mobile (375px or DevTools mobile emulation): poster cards show **no overlay** — clean image with title + subtitle below
- [ ] Desktop: hovering a poster card slides the dark overlay + logline up from the bottom as before
- [ ] Format/genre text ("Short · Drama" etc.) is clearly legible against the cream background on both mobile and desktop
- [ ] Tapping a card on mobile still navigates correctly (overlay being hidden does not block the link)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
