### PR TITLE
fix: add vertical padding to Credits section on About page

### DIFF
--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -179,7 +179,7 @@ export default function About() {
 
       {/* ── Selected credits ────────────────────────────────────────────────── */}
       {credits.length > 0 && (
-        <section className="section px-6" style={{ background: 'var(--color-bg-cream)' }}>
+        <section className="py-16 px-6" style={{ background: 'var(--color-bg-cream)' }}>
           <div className="container mx-auto max-w-4xl">
             <motion.div {...fadeUp(0)} className="eyebrow">Selected Credits</motion.div>
             <div className="mt-10 grid sm:grid-cols-2 lg:grid-cols-4 gap-8">


### PR DESCRIPTION
## Summary

The Credits section on the About page had zero vertical padding, causing it to sit flush against the pull quotes section above and the dark teal Recognition/Awards section below.

## Root cause

The `<section>` element used `className="section px-6"`, but `.section` is never defined anywhere in `index.css` or Tailwind config. It contributed no styles at all — leaving the Credits section with only the `px-6` horizontal padding and zero vertical padding.

## Fix

Replaced the phantom `section` class with `py-16` to match the vertical padding already used by the adjacent sections:

| Section | Padding |
|---|---|
| Pull quotes (above) | `py-16` |
| **Credits (this fix)** | ~~`section`~~ → `py-16` |
| Recognition / Awards (below) | `py-16` |

This restores a consistent 64px top-and-bottom rhythm so the Credits content breathes properly above and below.

## Files changed

- `frontend/src/pages/About.tsx` — 1 line changed (Credits `<section>` className)

## Test plan

- [ ] About page: Credits section has clear space above (between pull quotes and "Selected Credits" eyebrow)
- [ ] About page: Credits section has clear space below (cream background ends before teal Recognition block begins)
- [ ] No change to horizontal layout or content within the Credits section

🤖 Generated with [Claude Code](https://claude.com/claude-code)
