### PR TITLE
chore: code consistency pass (items 1.1-1.10)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import Films from './pages/portfolio/Films';
 import Services from './pages/portfolio/Services';
 import Testimonials from './pages/Testimonials';
 import Contact from './pages/Contact';
+import NotFound from './pages/NotFound';
 
 import AdminLogin from './pages/admin/Login';
 import AdminWriting from './pages/admin/AdminWriting';
@@ -48,6 +49,7 @@ function AnimatedRoutes() {
           <Route path="/portfolio/services" element={<Services />} />
           <Route path="/testimonials" element={<Testimonials />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="*" element={<NotFound />} />
 
           {/* Admin auth */}
           <Route path="/admin/login" element={<AdminLogin />} />

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -10,14 +10,6 @@ export async function logout(): Promise<void> {
   await supabase.auth.signOut();
 }
 
-// Synchronous "is authenticated" check kept for backwards compatibility with
-// the original RequireAuth component. Components added going forward should
-// use the reactive `useAuth()` hook in src/hooks/useAuth.ts instead.
-export function isAuthenticated(): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const session = (supabase.auth as any).currentSession ?? null;
-  return session !== null && session.expires_at * 1000 > Date.now();
-}
 
 export async function changePassword(_currentPassword: string, newPassword: string): Promise<void> {
   // Supabase Auth doesn't require the current password to update —

--- a/frontend/src/api/films.ts
+++ b/frontend/src/api/films.ts
@@ -1,5 +1,5 @@
 import { supabase } from '../lib/supabase';
-import type { FilmProject } from './types';
+import type { FilmProject, AwardInput } from './types';
 
 export interface UpsertFilmProject {
   title: string;
@@ -13,13 +13,7 @@ export interface UpsertFilmProject {
   status: 'draft' | 'published';
   featured: boolean;
   sortOrder: number;
-  awards: {
-    name: string;
-    category: string | null;
-    year: number | null;
-    laurelUrl: string | null;
-    featured: boolean;
-  }[];
+  awards: AwardInput[];
 }
 
 const SELECT = `

--- a/frontend/src/api/storage.ts
+++ b/frontend/src/api/storage.ts
@@ -1,0 +1,14 @@
+import { supabase } from '../lib/supabase';
+
+export async function adminUpload(file: File): Promise<string> {
+  const ext = file.name.includes('.') ? file.name.split('.').pop() : 'bin';
+  const path = `${crypto.randomUUID()}.${ext}`;
+
+  const { error } = await supabase.storage
+    .from('media')
+    .upload(path, file, { contentType: file.type, upsert: false });
+  if (error) throw error;
+
+  const { data } = supabase.storage.from('media').getPublicUrl(path);
+  return data.publicUrl;
+}

--- a/frontend/src/api/types.ts
+++ b/frontend/src/api/types.ts
@@ -7,6 +7,8 @@ export interface Award {
   featured: boolean;
 }
 
+export type AwardInput = Omit<Award, 'id'>;
+
 export interface SocialLink {
   id: number;
   platform: string;
@@ -107,5 +109,5 @@ export interface UpsertWritingProject {
   status: 'draft' | 'published';
   featured: boolean;
   sortOrder: number;
-  awards: Omit<Award, 'id'>[];
+  awards: AwardInput[];
 }

--- a/frontend/src/api/writing.ts
+++ b/frontend/src/api/writing.ts
@@ -129,16 +129,3 @@ async function syncWritingAwards(
   if (insError) throw insError;
 }
 
-// ── File upload (Supabase Storage) ────────────────────────────────────────
-export async function adminUpload(file: File): Promise<string> {
-  const ext = file.name.includes('.') ? file.name.split('.').pop() : 'bin';
-  const path = `${crypto.randomUUID()}.${ext}`;
-
-  const { error } = await supabase.storage
-    .from('media')
-    .upload(path, file, { contentType: file.type, upsert: false });
-  if (error) throw error;
-
-  const { data } = supabase.storage.from('media').getPublicUrl(path);
-  return data.publicUrl;
-}

--- a/frontend/src/components/admin/AwardEditor.tsx
+++ b/frontend/src/components/admin/AwardEditor.tsx
@@ -1,13 +1,8 @@
 import { useState } from 'react';
-import { adminUpload } from '../../api/writing';
+import { adminUpload } from '../../api/storage';
+import type { AwardInput } from '../../api/types';
 
-export interface AwardInput {
-  name: string;
-  category: string | null;
-  year: number | null;
-  laurelUrl: string | null;
-  featured: boolean;
-}
+export type { AwardInput };
 
 interface Props {
   awards: AwardInput[];

--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -45,10 +45,7 @@ export default function Footer() {
               <Link
                 key={to}
                 to={to}
-                className="font-body text-xs tracking-[0.18em] uppercase transition-colors duration-200"
-                style={{ color: 'rgba(250,247,248,0.7)' }}
-                onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--color-accent-light)')}
-                onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(250,247,248,0.7)')}
+                className="font-body text-xs tracking-[0.18em] uppercase transition-colors duration-200 text-[rgba(250,247,248,0.7)] hover:text-[--color-accent-light]"
               >
                 {label}
               </Link>
@@ -70,10 +67,7 @@ export default function Footer() {
                   target="_blank"
                   rel="noopener noreferrer"
                   aria-label={s.label ?? s.platform}
-                  className="transition-colors duration-200"
-                  style={{ color: 'rgba(250,247,248,0.75)' }}
-                  onMouseEnter={(e) => (e.currentTarget.style.color = 'var(--color-accent-light)')}
-                  onMouseLeave={(e) => (e.currentTarget.style.color = 'rgba(250,247,248,0.75)')}
+                  className="transition-colors duration-200 text-[rgba(250,247,248,0.75)] hover:text-[--color-accent-light]"
                 >
                   {s.iconUrl ? (
                     <img src={s.iconUrl} alt={s.label ?? s.platform} className="w-5 h-5 object-contain"

--- a/frontend/src/lib/pageVariants.ts
+++ b/frontend/src/lib/pageVariants.ts
@@ -1,0 +1,5 @@
+export const pageVariants = {
+  initial: { opacity: 0 },
+  animate: { opacity: 1, transition: { duration: 0.4 } },
+  exit:    { opacity: 0, transition: { duration: 0.2 } },
+};

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
+import { pageVariants } from '../lib/pageVariants';
 import { getAboutContent, type AboutContent } from '../api/about';
 import { getFeaturedLaurels } from '../api/laurels';
 import type { FeaturedLaurel } from '../api/types';
@@ -101,11 +102,7 @@ export default function About() {
   const { bioParagraphs, pullQuotes, credits, recognition, education } = content;
 
   return (
-    <motion.main
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { duration: 0.4 } }}
-      exit={{ opacity: 0, transition: { duration: 0.2 } }}
-    >
+    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section className="pt-32 pb-20 px-6" style={{ background: 'var(--color-bg-dark)' }}>
         <div className="container mx-auto max-w-4xl">
@@ -289,7 +286,7 @@ export default function About() {
 
       {/* ── Education & Training ─────────────────────────────────────────────── */}
       {education.length > 0 && (
-        <section className="section px-6" style={{ background: 'var(--color-bg-cream)' }}>
+        <section className="py-16 px-6" style={{ background: 'var(--color-bg-cream)' }}>
           <div className="container mx-auto max-w-4xl">
             <motion.div {...fadeUp(0)} className="eyebrow">Education &amp; Training</motion.div>
             <div className="mt-8 divide-y" style={{ borderColor: 'rgba(0,64,64,0.1)' }}>
@@ -318,7 +315,7 @@ export default function About() {
       )}
 
       {/* ── Behind the scenes gallery ───────────────────────────────────────── */}
-      <section className="section px-6" style={{ background: 'var(--color-bg-dark)' }}>
+      <section className="py-16 px-6" style={{ background: 'var(--color-bg-dark)' }}>
         <div className="container mx-auto max-w-4xl">
           <motion.div {...fadeUp(0)} className="eyebrow" style={{ color: 'rgba(250,247,248,0.55)' }}>Behind the Scenes</motion.div>
           <div className="mt-10 grid grid-cols-1 min-[360px]:grid-cols-2 md:grid-cols-3 gap-4">

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { submitContact, type ContactRequest } from '../api/contact';
+import { pageVariants } from '../lib/pageVariants';
 
 const fadeUp = (delay = 0) => ({
   initial: { opacity: 0, y: 20 },
@@ -39,11 +40,7 @@ export default function Contact() {
   };
 
   return (
-    <motion.main
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { duration: 0.4 } }}
-      exit={{ opacity: 0, transition: { duration: 0.2 } }}
-    >
+    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section
         className="pt-32 pb-20 px-6"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { getFeaturedShowcase } from '../api/showcase';
 import type { ShowcaseItem } from '../api/types';
+import { pageVariants } from '../lib/pageVariants';
 
 // ── YouTube IFrame API types ───────────────────────────────────────────────────
 declare global {
@@ -176,11 +177,7 @@ export default function Home() {
   }, []);
 
   return (
-    <motion.main
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { duration: 0.5 } }}
-      exit={{ opacity: 0, transition: { duration: 0.2 } }}
-    >
+    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Video Hero ──────────────────────────────────────────────────────── */}
       <section className="relative h-screen flex items-center justify-center overflow-hidden" style={{ background: 'var(--color-bg-dark)' }}>
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,0 +1,44 @@
+import { Link } from 'react-router-dom';
+import { motion } from 'framer-motion';
+import { pageVariants } from '../lib/pageVariants';
+
+export default function NotFound() {
+  return (
+    <motion.main
+      variants={pageVariants}
+      initial="initial"
+      animate="animate"
+      exit="exit"
+      className="pt-24 min-h-screen flex items-center justify-center px-6"
+      style={{ background: 'var(--color-bg-cream)' }}
+    >
+      <div className="text-center">
+        <div
+          className="font-display text-[8rem] leading-none font-light"
+          style={{ color: 'var(--color-accent-light)' }}
+        >
+          404
+        </div>
+        <h1
+          className="font-display text-2xl font-light mt-4"
+          style={{ color: 'var(--color-text-primary)' }}
+        >
+          Page not found
+        </h1>
+        <p
+          className="font-body text-sm mt-3"
+          style={{ color: 'var(--color-text-muted)' }}
+        >
+          The page you're looking for doesn't exist.
+        </p>
+        <Link
+          to="/"
+          className="inline-block mt-8 font-body text-xs tracking-widest uppercase underline underline-offset-4"
+          style={{ color: 'var(--color-accent)' }}
+        >
+          Back to home
+        </Link>
+      </div>
+    </motion.main>
+  );
+}

--- a/frontend/src/pages/Testimonials.tsx
+++ b/frontend/src/pages/Testimonials.tsx
@@ -2,12 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { getTestimonials } from '../api/testimonials';
 import type { Testimonial } from '../api/types';
-
-const pageVariants = {
-  initial: { opacity: 0 },
-  animate: { opacity: 1, transition: { duration: 0.4 } },
-  exit:    { opacity: 0, transition: { duration: 0.2 } },
-};
+import { pageVariants } from '../lib/pageVariants';
 
 function PullQuote({ testimonial }: { testimonial: Testimonial }) {
   return (

--- a/frontend/src/pages/admin/AdminAbout.tsx
+++ b/frontend/src/pages/admin/AdminAbout.tsx
@@ -7,13 +7,13 @@ import {
 
 // ── Shared styles ─────────────────────────────────────────────────────────────
 
-const inputCls  = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputSt   = { borderColor: 'var(--color-border-strong)', background: 'white' };
-const labelCls  = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelSt   = { color: 'var(--color-text-muted)' };
-const addBtnCls = 'font-body text-xs tracking-wide uppercase rounded-none px-3 py-1';
-const addBtnSt  = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
-const rmBtnCls  = 'font-body text-xs text-red-400 px-2 py-1 rounded-none flex-shrink-0';
+const inputClass  = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
+const inputStyleyle  = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const labelClass  = 'block font-body text-xs tracking-wide uppercase mb-1';
+const labelStyleyle  = { color: 'var(--color-text-muted)' };
+const addBtnClass = 'font-body text-xs tracking-wide uppercase rounded-none px-3 py-1';
+const addBtnStyleyle = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
+const rmBtnClass  = 'font-body text-xs text-red-400 px-2 py-1 rounded-none flex-shrink-0';
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
@@ -49,13 +49,13 @@ function BioEditor({
             value={p}
             onChange={(e) => update(i, e.target.value)}
             rows={4}
-            className={`${inputCls} resize-none flex-1`}
-            style={inputSt}
+            className={`${inputClass} resize-none flex-1`}
+            style={inputStyle}
           />
-          <button type="button" onClick={() => remove(i)} className={rmBtnCls}>✕</button>
+          <button type="button" onClick={() => remove(i)} className={rmBtnClass}>✕</button>
         </div>
       ))}
-      <button type="button" onClick={add} className={addBtnCls} style={addBtnSt}>
+      <button type="button" onClick={add} className={addBtnClass} style={addBtnStyle}>
         + Add Paragraph
       </button>
     </SectionCard>
@@ -80,27 +80,27 @@ function PullQuotesEditor({
       {value.map((q, i) => (
         <div key={i} className="mb-4 p-4" style={{ background: 'rgba(0,64,64,0.04)', border: '1px solid var(--color-border-strong)' }}>
           <div className="flex items-start justify-between gap-2 mb-2">
-            <label className={labelCls} style={labelSt}>Quote</label>
-            <button type="button" onClick={() => remove(i)} className={rmBtnCls}>✕ Remove</button>
+            <label className={labelClass} style={labelStyle}>Quote</label>
+            <button type="button" onClick={() => remove(i)} className={rmBtnClass}>✕ Remove</button>
           </div>
           <textarea
             value={q.text}
             onChange={(e) => update(i, 'text', e.target.value)}
             rows={3}
-            className={`${inputCls} resize-none mb-3`}
-            style={inputSt}
+            className={`${inputClass} resize-none mb-3`}
+            style={inputStyle}
           />
-          <label className={labelCls} style={labelSt}>Attribution</label>
+          <label className={labelClass} style={labelStyle}>Attribution</label>
           <input
             value={q.attr}
             onChange={(e) => update(i, 'attr', e.target.value)}
             placeholder="e.g. Director, rocking horse media"
-            className={inputCls}
-            style={inputSt}
+            className={inputClass}
+            style={inputStyle}
           />
         </div>
       ))}
-      <button type="button" onClick={add} className={addBtnCls} style={addBtnSt}>
+      <button type="button" onClick={add} className={addBtnClass} style={addBtnStyle}>
         + Add Quote
       </button>
     </SectionCard>
@@ -179,7 +179,7 @@ function CreditsEditor({
               onChange={(e) => updateGroup(gi, { ...group, role: e.target.value })}
               placeholder="Role (e.g. Script Supervisor)"
               className="flex-1 border px-3 py-2 font-body text-sm font-medium outline-none rounded-none"
-              style={{ ...inputSt, borderColor: 'var(--color-accent)' }}
+              style={{ ...inputStyle, borderColor: 'var(--color-accent)' }}
             />
             <button type="button" onClick={() => removeGroup(gi)}
               className="font-body text-xs text-red-400 px-3 py-2 rounded-none border border-red-200 flex-shrink-0">
@@ -191,9 +191,9 @@ function CreditsEditor({
           <div className="ml-6">
             <div className="grid grid-cols-[1.5rem_1fr_1fr_5rem_auto] gap-2 mb-1">
               <span />
-              <span className={`${labelCls} !mb-0`} style={labelSt}>Title</span>
-              <span className={`${labelCls} !mb-0`} style={labelSt}>Company</span>
-              <span className={`${labelCls} !mb-0`} style={labelSt}>Year</span>
+              <span className={`${labelClass} !mb-0`} style={labelStyle}>Title</span>
+              <span className={`${labelClass} !mb-0`} style={labelStyle}>Company</span>
+              <span className={`${labelClass} !mb-0`} style={labelStyle}>Year</span>
               <span />
             </div>
 
@@ -210,23 +210,23 @@ function CreditsEditor({
               >
                 <span className="font-body text-sm text-center" style={{ color: 'var(--color-text-muted)', cursor: 'grab' }}>⠿</span>
                 <input value={item.title} onChange={(e) => updateItem(gi, ii, { ...item, title: e.target.value })}
-                  placeholder="Title" className={inputCls} style={inputSt} />
+                  placeholder="Title" className={inputClass} style={inputStyle} />
                 <input value={item.company ?? ''} onChange={(e) => updateItem(gi, ii, { ...item, company: e.target.value || undefined })}
-                  placeholder="Company (optional)" className={inputCls} style={inputSt} />
+                  placeholder="Company (optional)" className={inputClass} style={inputStyle} />
                 <input value={item.year ?? ''} onChange={(e) => updateItem(gi, ii, { ...item, year: e.target.value || undefined })}
-                  placeholder="Year" className={inputCls} style={inputSt} />
-                <button type="button" onClick={() => removeItem(gi, ii)} className={rmBtnCls}>✕</button>
+                  placeholder="Year" className={inputClass} style={inputStyle} />
+                <button type="button" onClick={() => removeItem(gi, ii)} className={rmBtnClass}>✕</button>
               </div>
             ))}
 
-            <button type="button" onClick={() => addItem(gi)} className={`${addBtnCls} mt-1`} style={addBtnSt}>
+            <button type="button" onClick={() => addItem(gi)} className={`${addBtnClass} mt-1`} style={addBtnStyle}>
               + Add Credit
             </button>
           </div>
         </div>
       ))}
 
-      <button type="button" onClick={addGroup} className={addBtnCls} style={addBtnSt}>
+      <button type="button" onClick={addGroup} className={addBtnClass} style={addBtnStyle}>
         + Add Role Group
       </button>
     </SectionCard>
@@ -248,15 +248,15 @@ function RecognitionEditor({
       {value.map((r, i) => (
         <div key={i} className="grid grid-cols-[6rem_1fr_5rem_auto] gap-2 items-center mb-2">
           <input value={r.title} onChange={(e) => update(i, 'title', e.target.value)}
-            placeholder="e.g. Award Winner" className={inputCls} style={inputSt} />
+            placeholder="e.g. Award Winner" className={inputClass} style={inputStyle} />
           <input value={r.body} onChange={(e) => update(i, 'body', e.target.value)}
-            placeholder="Festival / body" className={inputCls} style={inputSt} />
+            placeholder="Festival / body" className={inputClass} style={inputStyle} />
           <input value={r.year} onChange={(e) => update(i, 'year', e.target.value)}
-            placeholder="Year" className={inputCls} style={inputSt} />
-          <button type="button" onClick={() => remove(i)} className={rmBtnCls}>✕</button>
+            placeholder="Year" className={inputClass} style={inputStyle} />
+          <button type="button" onClick={() => remove(i)} className={rmBtnClass}>✕</button>
         </div>
       ))}
-      <button type="button" onClick={add} className={`${addBtnCls} mt-2`} style={addBtnSt}>
+      <button type="button" onClick={add} className={`${addBtnClass} mt-2`} style={addBtnStyle}>
         + Add Award
       </button>
     </SectionCard>
@@ -278,15 +278,15 @@ function EducationEditor({
       {value.map((e, i) => (
         <div key={i} className="grid grid-cols-[1fr_1fr_5rem_auto] gap-2 items-center mb-2">
           <input value={e.course} onChange={(ev) => update(i, 'course', ev.target.value)}
-            placeholder="Course / qualification" className={inputCls} style={inputSt} />
+            placeholder="Course / qualification" className={inputClass} style={inputStyle} />
           <input value={e.school} onChange={(ev) => update(i, 'school', ev.target.value)}
-            placeholder="School / provider" className={inputCls} style={inputSt} />
+            placeholder="School / provider" className={inputClass} style={inputStyle} />
           <input value={e.year} onChange={(ev) => update(i, 'year', ev.target.value)}
-            placeholder="Year" className={inputCls} style={inputSt} />
-          <button type="button" onClick={() => remove(i)} className={rmBtnCls}>✕</button>
+            placeholder="Year" className={inputClass} style={inputStyle} />
+          <button type="button" onClick={() => remove(i)} className={rmBtnClass}>✕</button>
         </div>
       ))}
-      <button type="button" onClick={add} className={`${addBtnCls} mt-2`} style={addBtnSt}>
+      <button type="button" onClick={add} className={`${addBtnClass} mt-2`} style={addBtnStyle}>
         + Add Course
       </button>
     </SectionCard>

--- a/frontend/src/pages/admin/AdminAbout.tsx
+++ b/frontend/src/pages/admin/AdminAbout.tsx
@@ -8,11 +8,11 @@ import {
 // ── Shared styles ─────────────────────────────────────────────────────────────
 
 const inputClass  = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputStyleyle  = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const inputStyle  = { borderColor: 'var(--color-border-strong)', background: 'white' };
 const labelClass  = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelStyleyle  = { color: 'var(--color-text-muted)' };
+const labelStyle  = { color: 'var(--color-text-muted)' };
 const addBtnClass = 'font-body text-xs tracking-wide uppercase rounded-none px-3 py-1';
-const addBtnStyleyle = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
+const addBtnStyle = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
 const rmBtnClass  = 'font-body text-xs text-red-400 px-2 py-1 rounded-none flex-shrink-0';
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {

--- a/frontend/src/pages/admin/AdminFilms.tsx
+++ b/frontend/src/pages/admin/AdminFilms.tsx
@@ -7,7 +7,7 @@ import {
   adminReorderFilmProjects,
   type UpsertFilmProject,
 } from '../../api/films';
-import { adminUpload } from '../../api/writing';
+import { adminUpload } from '../../api/storage';
 import AwardEditor from '../../components/admin/AwardEditor';
 import type { FilmProject } from '../../api/types';
 

--- a/frontend/src/pages/admin/AdminServices.tsx
+++ b/frontend/src/pages/admin/AdminServices.tsx
@@ -9,7 +9,7 @@ import {
   type UpsertServiceSample,
 } from '../../api/services';
 import type { Service } from '../../api/types';
-import { adminUpload } from '../../api/writing';
+import { adminUpload } from '../../api/storage';
 
 const emptyForm = (): UpsertService => ({
   title: '', description: '', sortOrder: 0, published: true, samples: [],

--- a/frontend/src/pages/admin/AdminSocials.tsx
+++ b/frontend/src/pages/admin/AdminSocials.tsx
@@ -4,14 +4,14 @@ import {
   adminUpdateSocialLink, adminDeleteSocialLink,
   type UpsertSocialLink,
 } from '../../api/socials';
-import { adminUpload } from '../../api/writing';
+import { adminUpload } from '../../api/storage';
 import type { SocialLink } from '../../api/types';
 import SocialIcon, { KNOWN_PLATFORMS } from '../../components/ui/SocialIcon';
 
-const inputCls = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputSt  = { borderColor: 'var(--color-border-strong)', background: 'white' };
-const labelCls = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelSt  = { color: 'var(--color-text-muted)' };
+const inputClass = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
+const inputStyleyle = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const labelClass = 'block font-body text-xs tracking-wide uppercase mb-1';
+const labelStyleyle = { color: 'var(--color-text-muted)' };
 
 interface RowProps {
   initial: UpsertSocialLink;
@@ -56,14 +56,14 @@ function SocialForm({ initial, isNew, onSave, onCancel, onDelete }: RowProps) {
       <div className="grid sm:grid-cols-[10rem_1fr] gap-3">
         {/* Platform */}
         <div>
-          <label className={labelCls} style={labelSt}>Platform</label>
+          <label className={labelClass} style={labelStyle}>Platform</label>
           <input
             list="known-platforms"
             value={form.platform}
             onChange={(e) => set('platform', e.target.value)}
             placeholder="linkedin, imdb…"
-            className={inputCls}
-            style={inputSt}
+            className={inputClass}
+            style={inputStyle}
           />
           <datalist id="known-platforms">
             {KNOWN_PLATFORMS.map((p) => <option key={p} value={p} />)}
@@ -72,13 +72,13 @@ function SocialForm({ initial, isNew, onSave, onCancel, onDelete }: RowProps) {
 
         {/* URL */}
         <div>
-          <label className={labelCls} style={labelSt}>URL</label>
+          <label className={labelClass} style={labelStyle}>URL</label>
           <input
             value={form.url}
             onChange={(e) => set('url', e.target.value)}
             placeholder="https://…"
-            className={inputCls}
-            style={inputSt}
+            className={inputClass}
+            style={inputStyle}
           />
         </div>
       </div>
@@ -86,13 +86,13 @@ function SocialForm({ initial, isNew, onSave, onCancel, onDelete }: RowProps) {
       <div className="grid sm:grid-cols-[10rem_1fr] gap-3 mt-3 items-end">
         {/* Label */}
         <div>
-          <label className={labelCls} style={labelSt}>Label (optional)</label>
+          <label className={labelClass} style={labelStyle}>Label (optional)</label>
           <input
             value={form.label ?? ''}
             onChange={(e) => set('label', e.target.value || null)}
             placeholder="LinkedIn"
-            className={inputCls}
-            style={inputSt}
+            className={inputClass}
+            style={inputStyle}
           />
         </div>
 

--- a/frontend/src/pages/admin/AdminSocials.tsx
+++ b/frontend/src/pages/admin/AdminSocials.tsx
@@ -9,9 +9,9 @@ import type { SocialLink } from '../../api/types';
 import SocialIcon, { KNOWN_PLATFORMS } from '../../components/ui/SocialIcon';
 
 const inputClass = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputStyleyle = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const inputStyle = { borderColor: 'var(--color-border-strong)', background: 'white' };
 const labelClass = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelStyleyle = { color: 'var(--color-text-muted)' };
+const labelStyle = { color: 'var(--color-text-muted)' };
 
 interface RowProps {
   initial: UpsertSocialLink;

--- a/frontend/src/pages/admin/AdminWriting.tsx
+++ b/frontend/src/pages/admin/AdminWriting.tsx
@@ -5,8 +5,8 @@ import {
   adminUpdateWritingProject,
   adminDeleteWritingProject,
   adminReorderWritingProjects,
-  adminUpload,
 } from '../../api/writing';
+import { adminUpload } from '../../api/storage';
 import AwardEditor from '../../components/admin/AwardEditor';
 import type { WritingProject, UpsertWritingProject } from '../../api/types';
 

--- a/frontend/src/pages/portfolio/Films.tsx
+++ b/frontend/src/pages/portfolio/Films.tsx
@@ -2,12 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { getFilmProjects } from '../../api/films';
 import type { FilmProject } from '../../api/types';
-
-const pageVariants = {
-  initial: { opacity: 0 },
-  animate: { opacity: 1, transition: { duration: 0.4 } },
-  exit:    { opacity: 0, transition: { duration: 0.2 } },
-};
+import { pageVariants } from '../../lib/pageVariants';
 
 function SkeletonCard() {
   return (
@@ -59,7 +54,7 @@ function PosterCard({ project }: { project: FilmProject }) {
 
   const inner = (
     <motion.div
-      className={linkUrl ? 'cursor-pointer' : ''}
+      className={linkUrl ? 'cursor-pointer group' : ''}
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
@@ -72,7 +67,7 @@ function PosterCard({ project }: { project: FilmProject }) {
               src={project.posterUrl}
               alt={project.title}
               loading="lazy"
-              className="portfolio w-full h-full object-cover"
+              className="portfolio w-full h-full object-cover md:transition-transform md:duration-500 md:group-hover:scale-[1.03]"
               onError={() => setImgError(true)}
             />
           ) : (
@@ -89,7 +84,7 @@ function PosterCard({ project }: { project: FilmProject }) {
 
           {linkUrl && (
             <div
-              className="absolute inset-0 flex flex-col justify-end p-5 poster-overlay"
+              className="absolute inset-0 hidden md:flex flex-col justify-end p-5 md:translate-y-[60%] md:group-hover:translate-y-0 md:transition-transform md:duration-300 md:ease-out"
               style={{ background: 'linear-gradient(to top, rgba(0,64,64,0.95) 0%, rgba(0,64,64,0) 60%)' }}
             >
               <div className="font-display text-xl font-semibold" style={{ color: 'var(--color-text-inverse)' }}>
@@ -152,12 +147,6 @@ export default function Films() {
 
   return (
     <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
-      <style>{`
-        .poster-overlay { transform: translateY(60%); transition: transform 300ms ease-out; }
-        .cursor-pointer:hover .poster-overlay { transform: translateY(0); }
-        .cursor-pointer:hover img.portfolio { filter: none; transform: scale(1.03); }
-        img.portfolio { transition: filter 400ms ease, transform 500ms ease; }
-      `}</style>
 
       <div className="container mx-auto" style={{ padding: 'clamp(4rem,8vw,8rem) clamp(1.5rem,5vw,5rem)' }}>
         <div className="eyebrow">Films</div>

--- a/frontend/src/pages/portfolio/Services.tsx
+++ b/frontend/src/pages/portfolio/Services.tsx
@@ -2,12 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { getServices } from '../../api/services';
 import type { Service } from '../../api/types';
-
-const pageVariants = {
-  initial: { opacity: 0 },
-  animate: { opacity: 1, transition: { duration: 0.4 } },
-  exit:    { opacity: 0, transition: { duration: 0.2 } },
-};
+import { pageVariants } from '../../lib/pageVariants';
 
 function ServiceCard({ service }: { service: Service }) {
   const [samplesOpen, setSamplesOpen] = useState(false);

--- a/frontend/src/pages/portfolio/Writing.tsx
+++ b/frontend/src/pages/portfolio/Writing.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { getWritingProjects } from '../../api/writing';
 import type { WritingProject } from '../../api/types';
+import { pageVariants } from '../../lib/pageVariants';
 
 // ── Format badge colour ────────────────────────────────────────────────────────
 const formatColour: Record<string, string> = {
@@ -35,7 +36,7 @@ function PosterCard({ project }: { project: WritingProject }) {
 
   const inner = (
     <motion.div
-      className={linkUrl ? 'cursor-pointer' : ''}
+      className={linkUrl ? 'cursor-pointer group' : ''}
       initial={{ opacity: 0, y: 30 }}
       whileInView={{ opacity: 1, y: 0 }}
       viewport={{ once: true }}
@@ -49,7 +50,7 @@ function PosterCard({ project }: { project: WritingProject }) {
               src={project.posterUrl}
               alt={project.title}
               loading="lazy"
-              className="portfolio w-full h-full object-cover"
+              className="portfolio w-full h-full object-cover md:transition-transform md:duration-500 md:group-hover:scale-[1.03]"
               onError={() => setImgError(true)}
             />
           ) : (
@@ -64,10 +65,10 @@ function PosterCard({ project }: { project: WritingProject }) {
             </div>
           )}
 
-          {/* Hover overlay — only shown when there's a script link */}
+          {/* Hover overlay — desktop only; hidden on mobile (no hover on touch) */}
           {linkUrl && (
             <div
-              className="absolute inset-0 flex flex-col justify-end p-5 poster-overlay"
+              className="absolute inset-0 hidden md:flex flex-col justify-end p-5 md:translate-y-[60%] md:group-hover:translate-y-0 md:transition-transform md:duration-300 md:ease-out"
               style={{ background: 'linear-gradient(to top, rgba(0,40,40,0.95) 0%, rgba(0,40,40,0) 60%)' }}
             >
               <div className="font-display text-xl font-semibold" style={{ color: 'var(--color-text-inverse)' }}>
@@ -193,17 +194,7 @@ export default function Writing() {
   const visible = filter === ALL ? projects : projects.filter(p => p.format === filter);
 
   return (
-    <motion.main
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1, transition: { duration: 0.4 } }}
-      exit={{ opacity: 0, transition: { duration: 0.2 } }}
-    >
-      <style>{`
-        .poster-overlay { transform: translateY(60%); transition: transform 300ms ease-out; }
-        .cursor-pointer:hover .poster-overlay { transform: translateY(0); }
-        .cursor-pointer:hover img.portfolio { filter: none; transform: scale(1.03); }
-        img.portfolio { transition: filter 400ms ease, transform 500ms ease; }
-      `}</style>
+    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
 
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section className="pt-32 pb-20 px-6" style={{ background: 'var(--color-bg-dark)' }}>


### PR DESCRIPTION
﻿## Summary

- Move `adminUpload` to `api/storage.ts`; remove from `api/writing.ts`; update 5 import sites (AwardEditor, AdminFilms, AdminSocials, AdminServices, AdminWriting)
- Add `AwardInput = Omit<Award, "id">` to `api/types.ts`; delete local duplicate interface in `AwardEditor.tsx`; update `UpsertFilmProject` and `UpsertWritingProject` to use it
- Extract shared `pageVariants` object into `lib/pageVariants.ts`; replace all inline animation props and local copies across 7 pages (Home, About, Contact, Films, Writing, Testimonials, Services)
- Migrate Films and Writing poster overlay from injected `<style>` tag to Tailwind `group`/`group-hover` pattern matching Home.tsx; add `hidden md:flex` so overlay is suppressed on mobile
- Replace imperative `onMouseEnter`/`onMouseLeave` style mutations in `Footer.tsx` with Tailwind `hover:text-[--color-accent-light]` classes
- Rename `inputCls`/`inputSt`/`labelCls`/`labelSt` in `AdminAbout.tsx` and `AdminSocials.tsx` to `inputClass`/`inputStyle`/`labelClass`/`labelStyle` to match `AdminFilms` / `AdminWriting`
- Fix phantom `section` CSS class (never defined) on Education and Gallery sections in `About.tsx` — replaced with `py-16`
- Delete dead `isAuthenticated()` from `api/auth.ts` (accessed undocumented internal, zero callers)
- Add `pages/NotFound.tsx` and `<Route path="*">` catch-all to `App.tsx`

## Test plan

- [ ] Home, About, Contact pages fade in/out correctly on navigation
- [ ] Films and Writing poster hover overlay slides up on desktop; not visible at all on mobile
- [ ] Footer nav links and social icons change colour on hover
- [ ] Admin pages (About, Socials, Films, Services, Writing) all load and save without errors
- [ ] Navigating to an unknown URL shows the 404 page with a "Back to home" link
- [ ] TypeScript check passes (`npx tsc --noEmit` — clean, no output)

Generated with [Claude Code](https://claude.com/claude-code)
