### PR TITLE
fix/feat: security, a11y, and admin quality fixes

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -11,9 +11,17 @@ export async function logout(): Promise<void> {
 }
 
 
-export async function changePassword(_currentPassword: string, newPassword: string): Promise<void> {
-  // Supabase Auth doesn't require the current password to update —
-  // the session token authorises it. The arg is kept for the existing form UX.
+export async function changePassword(currentPassword: string, newPassword: string): Promise<void> {
+  const { data: { user }, error: userError } = await supabase.auth.getUser();
+  if (userError || !user?.email) throw new Error('Not authenticated');
+
+  // Re-authenticate to verify the current password before allowing the change
+  const { error: signInError } = await supabase.auth.signInWithPassword({
+    email: user.email,
+    password: currentPassword,
+  });
+  if (signInError) throw new Error('Current password is incorrect.');
+
   const { error } = await supabase.auth.updateUser({ password: newPassword });
   if (error) throw error;
 }

--- a/frontend/src/components/layout/Nav.tsx
+++ b/frontend/src/components/layout/Nav.tsx
@@ -47,6 +47,15 @@ export default function Nav() {
 
   return (
     <>
+      {/* Keyboard skip link — visually hidden until focused (WCAG 2.4.1) */}
+      <a
+        href="#main-content"
+        className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[200] focus:px-4 focus:py-2 focus:font-body focus:text-sm focus:tracking-wide"
+        style={{ background: 'var(--color-accent)', color: 'white' }}
+      >
+        Skip to main content
+      </a>
+
       <header
         className="fixed top-0 left-0 right-0 z-50 transition-all duration-300"
         style={

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -1,0 +1,10 @@
+import { useEffect } from 'react';
+
+const SITE = 'What A Line';
+
+export function usePageTitle(page?: string) {
+  useEffect(() => {
+    document.title = page ? `${page} | ${SITE}` : SITE;
+    return () => { document.title = SITE; };
+  }, [page]);
+}

--- a/frontend/src/pages/About.tsx
+++ b/frontend/src/pages/About.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { motion } from 'framer-motion';
 import { Link } from 'react-router-dom';
 import { pageVariants } from '../lib/pageVariants';
+import { usePageTitle } from '../hooks/usePageTitle';
 import { getAboutContent, type AboutContent } from '../api/about';
 import { getFeaturedLaurels } from '../api/laurels';
 import type { FeaturedLaurel } from '../api/types';
@@ -86,6 +87,7 @@ const FALLBACK: AboutContent = {
 };
 
 export default function About() {
+  usePageTitle('About');
   const [content, setContent] = useState<AboutContent>(FALLBACK);
   const [laurels, setLaurels] = useState<FeaturedLaurel[]>([]);
 
@@ -102,7 +104,7 @@ export default function About() {
   const { bioParagraphs, pullQuotes, credits, recognition, education } = content;
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section className="pt-32 pb-20 px-6" style={{ background: 'var(--color-bg-dark)' }}>
         <div className="container mx-auto max-w-4xl">

--- a/frontend/src/pages/Contact.tsx
+++ b/frontend/src/pages/Contact.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { submitContact, type ContactRequest } from '../api/contact';
 import { pageVariants } from '../lib/pageVariants';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 const fadeUp = (delay = 0) => ({
   initial: { opacity: 0, y: 20 },
@@ -15,6 +16,7 @@ const inputBase =
 type Status = 'idle' | 'sending' | 'success' | 'error';
 
 export default function Contact() {
+  usePageTitle('Contact');
   const [form, setForm] = useState<ContactRequest>({
     name: '', email: '', subject: '', message: '',
   });
@@ -40,7 +42,7 @@ export default function Contact() {
   };
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section
         className="pt-32 pb-20 px-6"

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { getFeaturedShowcase } from '../api/showcase';
 import type { ShowcaseItem } from '../api/types';
 import { pageVariants } from '../lib/pageVariants';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 // ── YouTube IFrame API types ───────────────────────────────────────────────────
 declare global {
@@ -105,6 +106,7 @@ function ShowcaseCard({ item }: { item: ShowcaseItem }) {
 }
 
 export default function Home() {
+  usePageTitle();
   const playerRef = useRef<YTPlayer | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [showcase, setShowcase] = useState<ShowcaseItem[]>([]);
@@ -177,7 +179,7 @@ export default function Home() {
   }, []);
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit">
       {/* ── Video Hero ──────────────────────────────────────────────────────── */}
       <section className="relative h-screen flex items-center justify-center overflow-hidden" style={{ background: 'var(--color-bg-dark)' }}>
 

--- a/frontend/src/pages/NotFound.tsx
+++ b/frontend/src/pages/NotFound.tsx
@@ -1,10 +1,13 @@
 import { Link } from 'react-router-dom';
 import { motion } from 'framer-motion';
 import { pageVariants } from '../lib/pageVariants';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 export default function NotFound() {
+  usePageTitle('404');
   return (
     <motion.main
+      id="main-content"
       variants={pageVariants}
       initial="initial"
       animate="animate"

--- a/frontend/src/pages/Testimonials.tsx
+++ b/frontend/src/pages/Testimonials.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { getTestimonials } from '../api/testimonials';
 import type { Testimonial } from '../api/types';
 import { pageVariants } from '../lib/pageVariants';
+import { usePageTitle } from '../hooks/usePageTitle';
 
 function PullQuote({ testimonial }: { testimonial: Testimonial }) {
   return (
@@ -38,6 +39,7 @@ function PullQuote({ testimonial }: { testimonial: Testimonial }) {
 }
 
 export default function Testimonials() {
+  usePageTitle('Testimonials');
   const [testimonials, setTestimonials] = useState<Testimonial[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -50,7 +52,7 @@ export default function Testimonials() {
   }, []);
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
       <div className="container mx-auto" style={{ padding: 'clamp(4rem,8vw,8rem) clamp(1.5rem,5vw,5rem)' }}>
         <div className="eyebrow">Testimonials</div>
         <h1 className="font-display text-4xl mb-16" style={{ color: 'var(--color-text-primary)' }}>

--- a/frontend/src/pages/admin/AdminAbout.tsx
+++ b/frontend/src/pages/admin/AdminAbout.tsx
@@ -127,7 +127,7 @@ function CreditsEditor({
   const [draggingItem,  setDraggingItem]  = useState<{ gi: number; ii: number } | null>(null);
 
   // ── Group helpers ────────────────────────────────────────────────────────
-  const updateGroup = (i: number, g: CreditGroup) =>
+  const updateGroup = (i: number, g: CreditGroupDraft) =>
     onChange(value.map((v, j) => j === i ? g : v));
   const removeGroup = (i: number) => onChange(value.filter((_, j) => j !== i));
   const addGroup    = () => onChange([...value, { role: '', items: [], _key: crypto.randomUUID() }]);
@@ -142,7 +142,7 @@ function CreditsEditor({
   };
 
   // ── Item helpers ─────────────────────────────────────────────────────────
-  const updateItem = (gi: number, ii: number, item: CreditItem) =>
+  const updateItem = (gi: number, ii: number, item: CreditItemDraft) =>
     updateGroup(gi, { ...value[gi], items: value[gi].items.map((it, j) => j === ii ? item : it) });
   const removeItem = (gi: number, ii: number) =>
     updateGroup(gi, { ...value[gi], items: value[gi].items.filter((_, j) => j !== ii) });

--- a/frontend/src/pages/admin/AdminAbout.tsx
+++ b/frontend/src/pages/admin/AdminAbout.tsx
@@ -5,14 +5,25 @@ import {
   type PullQuote, type RecognitionItem, type EducationItem,
 } from '../../api/about';
 
+// ── Client-side draft types (stable keys for React; stripped before saving) ───
+type CreditItemDraft  = CreditItem & { _key: string };
+type CreditGroupDraft = Omit<CreditGroup, 'items'> & { _key: string; items: CreditItemDraft[] };
+type AboutContentDraft = Omit<AboutContent, 'credits'> & { credits: CreditGroupDraft[] };
+
+const withKeys = (gs: CreditGroup[]): CreditGroupDraft[] =>
+  gs.map(g => ({ ...g, _key: crypto.randomUUID(), items: g.items.map(it => ({ ...it, _key: crypto.randomUUID() })) }));
+
+const stripKeys = (gs: CreditGroupDraft[]): CreditGroup[] =>
+  gs.map(({ _key: _gk, items, ...rest }) => ({ ...rest, items: items.map(({ _key: _ik, ...it }) => it) }));
+
 // ── Shared styles ─────────────────────────────────────────────────────────────
 
 const inputClass  = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputStyleyle  = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const inputStyle  = { borderColor: 'var(--color-border-strong)', background: 'white' };
 const labelClass  = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelStyleyle  = { color: 'var(--color-text-muted)' };
+const labelStyle  = { color: 'var(--color-text-muted)' };
 const addBtnClass = 'font-body text-xs tracking-wide uppercase rounded-none px-3 py-1';
-const addBtnStyleyle = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
+const addBtnStyle = { color: 'var(--color-accent)', border: '1px solid var(--color-accent)' };
 const rmBtnClass  = 'font-body text-xs text-red-400 px-2 py-1 rounded-none flex-shrink-0';
 
 function SectionCard({ title, children }: { title: string; children: React.ReactNode }) {
@@ -111,7 +122,7 @@ function PullQuotesEditor({
 
 function CreditsEditor({
   value, onChange,
-}: { value: CreditGroup[]; onChange: (v: CreditGroup[]) => void }) {
+}: { value: CreditGroupDraft[]; onChange: (v: CreditGroupDraft[]) => void }) {
   const [draggingGroup, setDraggingGroup] = useState<number | null>(null);
   const [draggingItem,  setDraggingItem]  = useState<{ gi: number; ii: number } | null>(null);
 
@@ -119,7 +130,7 @@ function CreditsEditor({
   const updateGroup = (i: number, g: CreditGroup) =>
     onChange(value.map((v, j) => j === i ? g : v));
   const removeGroup = (i: number) => onChange(value.filter((_, j) => j !== i));
-  const addGroup    = () => onChange([...value, { role: '', items: [] }]);
+  const addGroup    = () => onChange([...value, { role: '', items: [], _key: crypto.randomUUID() }]);
 
   const handleGroupDrop = (targetIdx: number) => {
     if (draggingGroup === null || draggingGroup === targetIdx) { setDraggingGroup(null); return; }
@@ -136,7 +147,7 @@ function CreditsEditor({
   const removeItem = (gi: number, ii: number) =>
     updateGroup(gi, { ...value[gi], items: value[gi].items.filter((_, j) => j !== ii) });
   const addItem    = (gi: number) =>
-    updateGroup(gi, { ...value[gi], items: [...value[gi].items, { title: '' }] });
+    updateGroup(gi, { ...value[gi], items: [...value[gi].items, { title: '', _key: crypto.randomUUID() }] });
 
   const handleItemDrop = (gi: number, targetIdx: number) => {
     if (!draggingItem || draggingItem.gi !== gi || draggingItem.ii === targetIdx) {
@@ -157,7 +168,7 @@ function CreditsEditor({
 
       {value.map((group, gi) => (
         <div
-          key={gi}
+          key={group._key}
           draggable
           onDragStart={(e) => { e.stopPropagation(); setDraggingGroup(gi); }}
           onDragOver={(e) => e.preventDefault()}
@@ -199,7 +210,7 @@ function CreditsEditor({
 
             {group.items.map((item, ii) => (
               <div
-                key={ii}
+                key={item._key}
                 draggable
                 onDragStart={(e) => { e.stopPropagation(); setDraggingItem({ gi, ii }); }}
                 onDragOver={(e) => e.preventDefault()}
@@ -296,7 +307,7 @@ function EducationEditor({
 // ── Main page ─────────────────────────────────────────────────────────────────
 
 export default function AdminAbout() {
-  const [content, setContent] = useState<AboutContent>({
+  const [content, setContent] = useState<AboutContentDraft>({
     bioParagraphs: [],
     pullQuotes: [],
     credits: [],
@@ -308,14 +319,16 @@ export default function AdminAbout() {
   const [saveMsg, setSaveMsg]   = useState<string | null>(null);
 
   useEffect(() => {
-    getAboutContent().then(setContent).finally(() => setLoading(false));
+    getAboutContent()
+      .then(data => setContent({ ...data, credits: withKeys(data.credits) }))
+      .finally(() => setLoading(false));
   }, []);
 
   const handleSave = async () => {
     setSaving(true);
     setSaveMsg(null);
     try {
-      await adminSaveAboutContent(content);
+      await adminSaveAboutContent({ ...content, credits: stripKeys(content.credits) });
       setSaveMsg('Saved ✓');
       setTimeout(() => setSaveMsg(null), 3000);
     } catch {
@@ -325,7 +338,7 @@ export default function AdminAbout() {
     }
   };
 
-  const update = <K extends keyof AboutContent>(key: K, val: AboutContent[K]) =>
+  const update = <K extends keyof AboutContentDraft>(key: K, val: AboutContentDraft[K]) =>
     setContent(c => ({ ...c, [key]: val }));
 
   if (loading) {

--- a/frontend/src/pages/admin/AdminContact.tsx
+++ b/frontend/src/pages/admin/AdminContact.tsx
@@ -11,12 +11,15 @@ function formatDate(iso: string) {
 export default function AdminContact() {
   const [items, setItems]     = useState<ContactSubmission[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState<string | null>(null);
   const [selected, setSelected] = useState<ContactSubmission | null>(null);
 
   const load = async () => {
     try {
       const data = await adminGetContacts();
       setItems(data);
+    } catch {
+      setError('Could not load messages. Check your connection and try refreshing.');
     } finally {
       setLoading(false);
     }
@@ -63,7 +66,11 @@ export default function AdminContact() {
         </p>
       )}
 
-      {!loading && items.length === 0 && (
+      {!loading && error && (
+        <p className="font-body text-sm" style={{ color: '#fca5a5' }}>{error}</p>
+      )}
+
+      {!loading && !error && items.length === 0 && (
         <div
           className="py-20 text-center font-body text-sm"
           style={{ color: 'var(--color-text-muted)' }}
@@ -72,7 +79,7 @@ export default function AdminContact() {
         </div>
       )}
 
-      {!loading && items.length > 0 && (
+      {!loading && !error && items.length > 0 && (
         <div className="grid lg:grid-cols-[320px_1fr] gap-4 h-[calc(100vh-140px)]">
 
           {/* Message list */}

--- a/frontend/src/pages/admin/AdminSettings.tsx
+++ b/frontend/src/pages/admin/AdminSettings.tsx
@@ -1,5 +1,6 @@
 import { useState, type FormEvent } from 'react';
 import { changePassword } from '../../api/auth';
+import { useAuth } from '../../hooks/useAuth';
 
 type Status = 'idle' | 'saving' | 'success' | 'error';
 
@@ -10,6 +11,7 @@ const labelClass = 'block font-body text-[11px] tracking-[0.18em] uppercase mb-1
 const labelStyle = { color: 'var(--color-text-muted)' };
 
 export default function AdminSettings() {
+  const { session } = useAuth();
   const [current, setCurrent]   = useState('');
   const [next, setNext]         = useState('');
   const [confirm, setConfirm]   = useState('');
@@ -38,9 +40,7 @@ export default function AdminSettings() {
       setConfirm('');
     } catch (err: unknown) {
       setStatus('error');
-      const msg =
-        (err as { response?: { data?: { message?: string } } })
-          ?.response?.data?.message ?? 'Something went wrong. Please try again.';
+      const msg = err instanceof Error ? err.message : 'Something went wrong. Please try again.';
       setErrorMsg(msg);
     }
   };
@@ -187,7 +187,10 @@ export default function AdminSettings() {
         <div className="flex items-center justify-between">
           <div>
             <p className="font-body text-sm" style={{ color: 'var(--color-text-inverse)' }}>
-              Signed in as <span style={{ color: 'var(--color-accent-light)' }}>kat</span>
+              Signed in as{' '}
+              <span style={{ color: 'var(--color-accent-light)' }}>
+                {session?.user.email ?? '…'}
+              </span>
             </p>
             <p className="font-body text-xs mt-0.5" style={{ color: 'var(--color-text-muted)' }}>
               Administrator

--- a/frontend/src/pages/admin/AdminSocials.tsx
+++ b/frontend/src/pages/admin/AdminSocials.tsx
@@ -9,9 +9,9 @@ import type { SocialLink } from '../../api/types';
 import SocialIcon, { KNOWN_PLATFORMS } from '../../components/ui/SocialIcon';
 
 const inputClass = 'w-full border px-3 py-2 font-body text-sm outline-none rounded-none';
-const inputStyleyle = { borderColor: 'var(--color-border-strong)', background: 'white' };
+const inputStyle = { borderColor: 'var(--color-border-strong)', background: 'white' };
 const labelClass = 'block font-body text-xs tracking-wide uppercase mb-1';
-const labelStyleyle = { color: 'var(--color-text-muted)' };
+const labelStyle = { color: 'var(--color-text-muted)' };
 
 interface RowProps {
   initial: UpsertSocialLink;

--- a/frontend/src/pages/portfolio/Films.tsx
+++ b/frontend/src/pages/portfolio/Films.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { getFilmProjects } from '../../api/films';
 import type { FilmProject } from '../../api/types';
 import { pageVariants } from '../../lib/pageVariants';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 function SkeletonCard() {
   return (
@@ -134,6 +135,7 @@ function PosterCard({ project }: { project: FilmProject }) {
 }
 
 export default function Films() {
+  usePageTitle('Films');
   const [projects, setProjects] = useState<FilmProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -146,7 +148,7 @@ export default function Films() {
   }, []);
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
 
       <div className="container mx-auto" style={{ padding: 'clamp(4rem,8vw,8rem) clamp(1.5rem,5vw,5rem)' }}>
         <div className="eyebrow">Films</div>

--- a/frontend/src/pages/portfolio/Services.tsx
+++ b/frontend/src/pages/portfolio/Services.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { getServices } from '../../api/services';
 import type { Service } from '../../api/types';
 import { pageVariants } from '../../lib/pageVariants';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 function ServiceCard({ service }: { service: Service }) {
   const [samplesOpen, setSamplesOpen] = useState(false);
@@ -79,6 +80,7 @@ function ServiceCard({ service }: { service: Service }) {
 }
 
 export default function Services() {
+  usePageTitle('Services');
   const [services, setServices] = useState<Service[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -91,7 +93,7 @@ export default function Services() {
   }, []);
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit" className="pt-24">
       <div className="container mx-auto" style={{ padding: 'clamp(4rem,8vw,8rem) clamp(1.5rem,5vw,5rem)' }}>
         <div className="eyebrow">Services</div>
         <h1 className="font-display text-4xl mb-12" style={{ color: 'var(--color-text-primary)' }}>

--- a/frontend/src/pages/portfolio/Writing.tsx
+++ b/frontend/src/pages/portfolio/Writing.tsx
@@ -3,6 +3,7 @@ import { motion } from 'framer-motion';
 import { getWritingProjects } from '../../api/writing';
 import type { WritingProject } from '../../api/types';
 import { pageVariants } from '../../lib/pageVariants';
+import { usePageTitle } from '../../hooks/usePageTitle';
 
 // ── Format badge colour ────────────────────────────────────────────────────────
 const formatColour: Record<string, string> = {
@@ -178,6 +179,7 @@ function getFormats(projects: WritingProject[]) {
 
 // ── Page ───────────────────────────────────────────────────────────────────────
 export default function Writing() {
+  usePageTitle('Writing');
   const [projects, setProjects] = useState<WritingProject[]>([]);
   const [loading, setLoading]   = useState(true);
   const [error, setError]       = useState<string | null>(null);
@@ -194,7 +196,7 @@ export default function Writing() {
   const visible = filter === ALL ? projects : projects.filter(p => p.format === filter);
 
   return (
-    <motion.main variants={pageVariants} initial="initial" animate="animate" exit="exit">
+    <motion.main id="main-content" variants={pageVariants} initial="initial" animate="animate" exit="exit">
 
       {/* ── Header ──────────────────────────────────────────────────────────── */}
       <section className="pt-32 pb-20 px-6" style={{ background: 'var(--color-bg-dark)' }}>

--- a/supabase/functions/contact-notify/index.ts
+++ b/supabase/functions/contact-notify/index.ts
@@ -24,8 +24,28 @@ const cors = {
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
+// Best-effort in-memory rate limit: 3 submissions per IP per minute.
+// Works while the function instance is warm; resets on cold start (acceptable for a portfolio).
+const rl = new Map<string, { n: number; until: number }>();
+function rateLimited(ip: string): boolean {
+  const now = Date.now();
+  const entry = rl.get(ip);
+  if (!entry || now > entry.until) { rl.set(ip, { n: 1, until: now + 60_000 }); return false; }
+  if (entry.n >= 3) return true;
+  entry.n++;
+  return false;
+}
+
 Deno.serve(async (req) => {
   if (req.method === 'OPTIONS') return new Response('ok', { headers: cors });
+
+  const ip = req.headers.get('x-forwarded-for')?.split(',')[0].trim() ?? 'unknown';
+  if (rateLimited(ip)) {
+    return new Response(JSON.stringify({ ok: false, error: 'Too many requests — please wait a moment.' }), {
+      status: 429,
+      headers: { ...cors, 'Content-Type': 'application/json' },
+    });
+  }
 
   try {
     const payload = (await req.json()) as ContactPayload;


### PR DESCRIPTION
﻿## Summary

- **Security:** `changePassword` now re-authenticates via `signInWithPassword` before updating — the current password is actually verified. Contact form Edge Function gets a best-effort in-memory IP rate limit (3/min, returns 429).
- **Accessibility:** Keyboard skip link added to Nav (WCAG 2.4.1); all 8 public pages have `id="main-content"` as the skip target.
- **Page titles:** New `usePageTitle` hook; every public page sets `document.title` (e.g. "Films | What A Line").
- **Admin fixes:** `AdminSettings` error message now reads from `err.message` (was Axios-style shape that never matched); "Signed in as" shows live session email not hardcoded "kat". `AdminContact` load error is now surfaced in the UI. `AdminAbout` credits drag-to-reorder uses stable `crypto.randomUUID()` keys (`CreditGroupDraft`/`CreditItemDraft`) instead of array index — fixes stale input values after dragging.

## Note

This branch is based on `chore/consistency` (PR #9). If #9 merges first, rebase this branch onto `main` before merging.

## Test plan

- [ ] Change password with wrong current password → shows "Current password is incorrect"
- [ ] Submitting contact form 4× in quick succession → 4th request returns 429 (observable in network tab)
- [ ] Tab to skip link on any page → link becomes visible; pressing Enter skips nav and focuses main content
- [ ] Browser tab shows correct title on each page ("About | What A Line" etc.)
- [ ] `AdminSettings` → Account section shows real email, not "kat"
- [ ] Disconnect network, open `/admin/contact` → shows error message instead of blank
- [ ] `AdminAbout` → drag a credit group to a different position → text fields stay with their item (not shuffle)
- [ ] TypeScript check passes (`npx tsc --noEmit` — clean)

Generated with [Claude Code](https://claude.com/claude-code)
