### PR TITLE
fix: show custom social icons in their natural colour

### DIFF
--- a/frontend/src/components/layout/Footer.tsx
+++ b/frontend/src/components/layout/Footer.tsx
@@ -70,8 +70,7 @@ export default function Footer() {
                   className="transition-colors duration-200 text-[rgba(250,247,248,0.75)] hover:text-[--color-accent-light]"
                 >
                   {s.iconUrl ? (
-                    <img src={s.iconUrl} alt={s.label ?? s.platform} className="w-5 h-5 object-contain"
-                      style={{ filter: 'brightness(0) invert(1)', opacity: 0.85 }} />
+                    <img src={s.iconUrl} alt={s.label ?? s.platform} className="w-5 h-5 object-contain" />
                   ) : (
                     <SocialIcon platform={s.platform} size={20} />
                   )}


### PR DESCRIPTION
## Summary

- Remove \ilter: brightness(0) invert(1)\ from custom-uploaded social icon images in the Footer
- The filter was designed for monochrome SVG icons (to make them white on the dark teal background), but it was also applied to uploaded PNG/JPG images, crushing all colours to white
- Custom logos like the ISA icon now render as uploaded, without any colour transformation

## Test plan

- [ ] Go to the site footer — ISA icon (and any other uploaded custom icons) should display in their natural colours
- [ ] Generic platform icons (LinkedIn, Instagram, etc.) are unaffected — they use the \SocialIcon\ component, not the \img\ path

Generated with [Claude Code](https://claude.com/claude-code)